### PR TITLE
Add automated KPI tracking workflow

### DIFF
--- a/.github/workflows/kpi-metrics.yml
+++ b/.github/workflows/kpi-metrics.yml
@@ -1,0 +1,68 @@
+name: KPI Metrics
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1" # Mo 06:00 UTC: Weekly aggregate
+
+permissions:
+  contents: write
+
+jobs:
+  collect-ci:
+    if: ${{ github.event_name == 'workflow_run' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 2 }
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - name: Write CI row
+        run: |
+          echo "CI_JOB_STATUS=${{ github.event.workflow_run.conclusion }}" >> $GITHUB_ENV
+          node scripts/kpi/collect_ci_run.js
+      - name: Commit metrics
+        run: |
+          git config user.name "kpi-bot"
+          git config user.email "kpi-bot@users.noreply.github.com"
+          git add .metrics/ci_runs.csv
+          git commit -m "kpi: append ci run (#${{ github.event.workflow_run.run_number }})" || echo "no changes"
+          git push
+
+  detect-auto-fix:
+    if: ${{ github.event_name == 'workflow_run' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 2 }
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - name: Detect auto-fix
+        run: node scripts/kpi/detect_auto_fix.js
+      - name: Commit metrics
+        run: |
+          git config user.name "kpi-bot"
+          git config user.email "kpi-bot@users.noreply.github.com"
+          git add .metrics/auto_fixes.csv
+          git commit -m "kpi: update auto-fix metrics" || echo "no changes"
+          git push
+
+  aggregate-week:
+    if: ${{ github.event_name != 'workflow_run' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - name: Aggregate weekly metrics
+        run: node scripts/kpi/aggregate_week.js
+      - name: Commit report
+        run: |
+          git config user.name "kpi-bot"
+          git config user.email "kpi-bot@users.noreply.github.com"
+          git add .metrics/weekly_report.md
+          git commit -m "kpi: weekly report"
+          git push

--- a/.metrics/README.md
+++ b/.metrics/README.md
@@ -1,0 +1,8 @@
+# .metrics — Automatische KPI-Daten
+
+Automatisch gepflegte Dateien:
+- `ci_runs.csv`: Abschluss jedes CI-Runs (Status, Attempt)
+- `auto_fixes.csv`: Erkennung von Auto-Fix-Commits
+- `weekly_report.md`: Aggregierte Woche (KPIs, Ampeln)
+
+Diese Daten werden durch `.github/workflows/kpi-metrics.yml` geschrieben.

--- a/.metrics/weekly_report.md
+++ b/.metrics/weekly_report.md
@@ -1,0 +1,16 @@
+# 📈 Weekly KPI Report
+
+| KPI | Wert | Ziel |
+|---|---|---|
+| Green-Rate (First Pass) | 0.0% | ≥ 95% |
+| Auto-Fix-Quote | 0.0% | ≥ 60% |
+| PR-Zykluszeit (Median) | n/a (Phase 2 automatisieren) | ≤ 24h |
+| Dokumentationsgrad | 50% | ≥ 90% |
+| Operator-Aufwand | n/a (Checkliste) | ≤ 3 |
+
+**Ampel**
+- Green-Rate: ⚠️
+- Auto-Fix-Quote: ⚠️
+- Doku: ⚠️
+
+_Notiz: PR-Zykluszeit & Operator-Aufwand werden vorerst in der Checkliste erfasst._

--- a/artefacts/kpi/Operator_KPI_Checklist.md
+++ b/artefacts/kpi/Operator_KPI_Checklist.md
@@ -1,0 +1,9 @@
+# ✅ Operator KPI Checklist (Weekly)
+
+- [ ] Green-Rate ≥ 95 % (siehe `.metrics/weekly_report.md`)
+- [ ] Median PR-Zykluszeit ≤ 24 h (trage hier den Wert ein: ____)
+- [ ] Auto-Fix-Quote ≥ 60 % (siehe `.metrics/weekly_report.md`)
+- [ ] Dokumentationsgrad ≥ 90 % (Systemkarte, Loop-Files, KPIs, Runbook vorhanden)
+- [ ] Operator-Aufwand ≤ 3 Schritte je Ticket (aktueller Median: ____)
+
+Hinweis: Werte, die noch nicht automatisch erfasst werden, bitte hier eintragen.

--- a/artefacts/kpi/Operator_KPIs.md
+++ b/artefacts/kpi/Operator_KPIs.md
@@ -1,16 +1,13 @@
 # 📊 Operator KPIs
 
-Ziel: Klare Messpunkte, ob das Arbeiten im System funktioniert und für den Operator einfach bleibt.  
-Die KPIs sind so formuliert, dass sie ohne technisches Fachwissen überprüfbar sind.
+Ziel: Messen, ob Arbeit im System leicht, schnell und stabil ist.
 
----
+| KPI | Definition | Messmethode | Zielwert |
+|---|---|---|---|
+| Green-Rate (First Pass) | Anteil PRs, die beim ersten Lauf grün sind | `.metrics/ci_runs.csv` → status==success & first_attempt==1 | ≥ 95 % |
+| PR-Zykluszeit (Median) | Zeit von Ticket-Erstellung bis Merge | manuell in `Operator_KPI_Checklist.md` (vorerst) | ≤ 24 h |
+| Auto-Fix-Quote | Anteil PRs mit erkanntem Auto-Fix (`[auto-fix]`) | `.metrics/auto_fixes.csv` | ≥ 60 % |
+| Dokumentationsgrad | Anteil Kern-Artefakte mit aktueller Version | File-Existenz + Änderungsdatum | ≥ 90 % |
+| Operator-Aufwand | Manuelle Schritte pro Ticket | `Operator_KPI_Checklist.md` | ≤ 3 |
 
-| KPI                | Definition                                                | Messmethode                                    | Zielwert |
-|---------------------|-----------------------------------------------------------|------------------------------------------------|----------|
-| **Green-Rate**      | Anteil der Pull Requests, die beim ersten Durchlauf ohne Fehler durchlaufen | CI-Status prüfen (grün beim ersten Lauf)       | ≥ 95 %   |
-| **PR-Zykluszeit**   | Zeit vom Erstellen eines Tickets bis zum Merge in den Hauptzweig | Zeitstempel „Ticket erstellt“ → „Merge erfolgt“ | ≤ 24 h   |
-| **Auto-Fix-Quote**  | Anteil der Fehler, die automatisch behoben werden (Lint, Format, Security) | Zählen von Auto-Fix-Commits im PR              | ≥ 60 %   |
-| **Dokumentationsgrad** | Anteil der Artefakte (Loops, KPIs, Runbooks), die aktuell gepflegt sind | Checklisten-Review einmal pro Woche            | ≥ 90 %   |
-| **Operator-Aufwand** | Anzahl der manuellen Schritte, die ein Operator pro Ticket erledigen muss | Zählen der Operator-Aktionen (DoR, DoD, Merge) | ≤ 3      |
-
----
+Weitere Automatisierung: Siehe `.github/workflows/kpi-metrics.yml`.

--- a/docs/KPI_Usage.md
+++ b/docs/KPI_Usage.md
@@ -1,0 +1,8 @@
+# 📘 KPI Usage (Operator)
+
+1) Täglich: Nichts tun – Metriken werden automatisch geschrieben.
+2) Wöchentlich (Montag):
+   - `artefacts/kpi/Operator_KPI_Checklist.md` ausfüllen.
+   - `.metrics/weekly_report.md` lesen (Ampel).
+3) Wenn Ziele verfehlt:
+   - Ticket anlegen (Root Cause → Gegenmaßnahme).

--- a/scripts/kpi/aggregate_week.js
+++ b/scripts/kpi/aggregate_week.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+function readCSV(p) {
+  if (!fs.existsSync(p)) return [];
+  const content = fs.readFileSync(p, 'utf8').trim();
+  if (!content) return [];
+  const [header, ...rows] = content.split('\n');
+  const keys = header.split(',');
+  return rows.map(r => {
+    const vals = r.split(',');
+    return Object.fromEntries(keys.map((k, i) => [k, vals[i] || '']));
+  });
+}
+
+const ci = readCSV(path.join('.metrics', 'ci_runs.csv'));
+const af = readCSV(path.join('.metrics', 'auto_fixes.csv'));
+
+const successfulFirst = ci.filter(r => r.status === 'success' && r.first_attempt === '1').length;
+const totalRuns = ci.length || 1;
+const greenRate = successfulFirst / totalRuns;
+
+const autoFixDetections = af.filter(r => r.detected === '1').length;
+const totalAF = af.length || 1;
+const autoFixRate = autoFixDetections / totalAF;
+
+const prCycleMedian = 'n/a (Phase 2 automatisieren)';
+const docFiles = [
+  'artefacts/loops/Systemkarte.md',
+  'artefacts/kpi/Operator_KPIs.md',
+  'artefacts/runbooks/Documentation_Layer.md',
+  'docs/OPERATOR_RUNBOOK.md'
+];
+const docCoverage = docFiles.reduce((acc, f) => acc + (fs.existsSync(f) ? 1 : 0), 0) / docFiles.length;
+
+const operatorEffort = 'n/a (Checkliste)';
+
+const report =
+`# 📈 Weekly KPI Report
+
+| KPI | Wert | Ziel |
+|---|---|---|
+| Green-Rate (First Pass) | ${(greenRate*100).toFixed(1)}% | ≥ 95% |
+| Auto-Fix-Quote | ${(autoFixRate*100).toFixed(1)}% | ≥ 60% |
+| PR-Zykluszeit (Median) | ${prCycleMedian} | ≤ 24h |
+| Dokumentationsgrad | ${(docCoverage*100).toFixed(0)}% | ≥ 90% |
+| Operator-Aufwand | ${operatorEffort} | ≤ 3 |
+
+**Ampel**
+- Green-Rate: ${greenRate >= 0.95 ? '✅' : '⚠️'}
+- Auto-Fix-Quote: ${autoFixRate >= 0.60 ? '✅' : '⚠️'}
+- Doku: ${docCoverage >= 0.90 ? '✅' : '⚠️'}
+
+_Notiz: PR-Zykluszeit & Operator-Aufwand werden vorerst in der Checkliste erfasst._
+`;
+
+const outPath = path.join('.metrics', 'weekly_report.md');
+if (!fs.existsSync(path.dirname(outPath))) fs.mkdirSync(path.dirname(outPath), { recursive: true });
+fs.writeFileSync(outPath, report, 'utf8');
+console.log('Wrote', outPath);

--- a/scripts/kpi/collect_ci_run.js
+++ b/scripts/kpi/collect_ci_run.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const outDir = path.join('.metrics');
+if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+
+const outFile = path.join(outDir, 'ci_runs.csv');
+if (!fs.existsSync(outFile)) {
+  fs.writeFileSync(outFile, 'timestamp,run_number,branch,sha,event,workflow,status,first_attempt\n');
+}
+
+const now = new Date().toISOString();
+const runNumber = process.env.GITHUB_RUN_NUMBER || '';
+const ref = process.env.GITHUB_REF || '';
+const branch = ref.replace('refs/heads/', '');
+const sha = process.env.GITHUB_SHA || '';
+const event = process.env.GITHUB_EVENT_NAME || '';
+const workflow = process.env.GITHUB_WORKFLOW || '';
+const status = process.env.CI_JOB_STATUS || process.env.JOB_STATUS || 'unknown';
+const firstAttempt = process.env.GITHUB_RUN_ATTEMPT === '1' ? '1' : '0';
+
+const line = `${now},${runNumber},${branch},${sha},${event},${workflow},${status},${firstAttempt}\n`;
+fs.appendFileSync(outFile, line, 'utf8');
+console.log('Appended:', line.trim());

--- a/scripts/kpi/detect_auto_fix.js
+++ b/scripts/kpi/detect_auto_fix.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function safeExec(cmd) {
+  try { return execSync(cmd, { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim(); }
+  catch { return ''; }
+}
+
+const msg = safeExec('git log -1 --pretty=%B');
+let files = safeExec('git diff --name-only HEAD^ HEAD');
+if (!files) {
+  files = safeExec('git show --pretty="" --name-only HEAD');
+}
+const autoFixByFiles = files.split('\n').some(name => /lint|format/i.test(name));
+const detected = (/\[auto-fix\]/i.test(msg) || autoFixByFiles) ? 1 : 0;
+
+const outDir = path.join('.metrics');
+if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+
+const outFile = path.join(outDir, 'auto_fixes.csv');
+if (!fs.existsSync(outFile)) {
+  fs.writeFileSync(outFile, 'timestamp,sha,detected\n');
+}
+
+const now = new Date().toISOString();
+const sha = process.env.GITHUB_SHA || safeExec('git rev-parse HEAD');
+fs.appendFileSync(outFile, `${now},${sha},${detected}\n`, 'utf8');
+console.log('auto-fix detected:', detected);


### PR DESCRIPTION
## Summary
- add operator-facing KPI checklist and usage guide
- implement Node scripts to collect CI runs, auto-fix signals, and weekly aggregates
- configure GitHub Actions workflow to persist KPI metrics and reports

## Testing
- node scripts/kpi/aggregate_week.js

------
https://chatgpt.com/codex/tasks/task_e_68d98b81cf58832e9d5610f4a8659f29