### PR TITLE
Add one-click automation workflow

### DIFF
--- a/.github/workflows/oneclick.yml
+++ b/.github/workflows/oneclick.yml
@@ -1,0 +1,226 @@
+name: One-Click Operations
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  checks: read
+  statuses: read
+
+jobs:
+  dry-run:
+    name: Dry Run Tests
+    if: |
+      github.event.issue.pull_request != null &&
+      github.event.comment.body != null &&
+      github.event.comment.body.trim() == '/dry-run'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run npm test
+        id: run-tests
+        run: npm test
+        continue-on-error: true
+
+      - name: Prepare result message
+        id: prepare-result
+        run: |
+          if [ "${{ steps.run-tests.outcome }}" = "success" ]; then
+            echo "result=✅ Tests erfolgreich." >> "$GITHUB_OUTPUT"
+          else
+            echo "result=❌ Tests fehlgeschlagen." >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post result comment
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          RESULT_MESSAGE: ${{ steps.prepare-result.outputs.result }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const {owner, repo} = context.repo;
+            const issue_number = context.payload.issue.number;
+            const body = process.env.RESULT_MESSAGE || 'Ergebnis unbekannt.';
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body
+            });
+
+      - name: Fail job if tests failed
+        if: steps.run-tests.outcome != 'success'
+        run: exit 1
+
+  apply:
+    name: Apply Changes
+    if: |
+      github.event.issue.pull_request != null &&
+      github.event.comment.body != null &&
+      github.event.comment.body.trim() == '/apply'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Execute apply workflow
+        id: apply
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const core = require('@actions/core');
+            const {owner, repo} = context.repo;
+            const pull_number = context.payload.issue.number;
+            const commenter = context.payload.comment.user.login;
+            const association = context.payload.comment.author_association;
+            const allowedAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR', 'MAINTAINER']);
+
+            const comment = async (body) => {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pull_number,
+                body
+              });
+            };
+
+            if (!allowedAssociations.has(association)) {
+              await comment(`❌ @${commenter}, du benötigst Schreibrechte, um /apply zu verwenden.`);
+              core.setFailed('User lacks write permissions for /apply');
+              return;
+            }
+
+            const {data: pr} = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number
+            });
+
+            if (pr.merged) {
+              await comment(`ℹ️ PR #${pull_number} wurde bereits gemerged.`);
+              return;
+            }
+
+            const sha = pr.head.sha;
+            const baseBranch = pr.base.ref;
+
+            const checkRuns = await github.paginate(
+              github.rest.checks.listForRef,
+              {
+                owner,
+                repo,
+                ref: sha,
+                per_page: 100
+              }
+            );
+
+            const pendingRun = checkRuns.find(run => run.status !== 'completed');
+            if (pendingRun) {
+              await comment(`⏳ CI-Prüfungen laufen noch ("${pendingRun.name}"). Bitte später erneut versuchen.`);
+              core.setFailed('CI checks pending');
+              return;
+            }
+
+            const failingRun = checkRuns.find(run => run.conclusion && !['success', 'neutral', 'skipped'].includes(run.conclusion));
+            if (failingRun) {
+              await comment(`❌ CI-Prüfung "${failingRun.name}" ist fehlgeschlagen.`);
+              core.setFailed('CI checks failing');
+              return;
+            }
+
+            const {data: combined} = await github.rest.repos.getCombinedStatusForRef({
+              owner,
+              repo,
+              ref: sha
+            });
+
+            if (combined.state === 'failure' || combined.state === 'error') {
+              await comment('❌ Commit-Status ist rot. Merge abgebrochen.');
+              core.setFailed('Commit status failure');
+              return;
+            }
+
+            if (combined.state === 'pending') {
+              await comment('⏳ Commit-Status ist noch nicht grün. Bitte später erneut versuchen.');
+              core.setFailed('Commit status pending');
+              return;
+            }
+
+            const mergeResult = await github.rest.pulls.merge({
+              owner,
+              repo,
+              pull_number
+            });
+
+            if (!mergeResult.data.merged) {
+              const message = mergeResult.data.message || 'Unbekannter Fehler';
+              await comment(`❌ Merge fehlgeschlagen: ${message}`);
+              core.setFailed('Merge API returned failure');
+              return;
+            }
+
+            const timestamp = new Date().toISOString();
+            const status = 'merged';
+            const logLine = `${timestamp},${pull_number},${commenter},${status}`;
+            const logPath = '.metrics/oneclick_log.csv';
+
+            let existingContent = '';
+            let currentSha;
+
+            try {
+              const {data: contentData} = await github.rest.repos.getContent({
+                owner,
+                repo,
+                path: logPath,
+                ref: baseBranch
+              });
+
+              if (Array.isArray(contentData)) {
+                throw new Error(`${logPath} is a directory`);
+              }
+
+              existingContent = Buffer.from(contentData.content, contentData.encoding).toString('utf8');
+              currentSha = contentData.sha;
+            } catch (error) {
+              if (error.status === 404) {
+                existingContent = 'timestamp,pr_number,user,status\n';
+              } else {
+                throw error;
+              }
+            }
+
+            if (!existingContent.endsWith('\n')) {
+              existingContent += '\n';
+            }
+
+            const updatedContent = existingContent + logLine + '\n';
+
+            const updateParams = {
+              owner,
+              repo,
+              path: logPath,
+              message: `chore: log one-click merge for #${pull_number}`,
+              content: Buffer.from(updatedContent, 'utf8').toString('base64'),
+              branch: baseBranch
+            };
+
+            if (currentSha) {
+              updateParams.sha = currentSha;
+            }
+
+            await github.rest.repos.createOrUpdateFileContents(updateParams);
+
+            await comment(`✅ PR #${pull_number} wurde von @${commenter} gemerged.`);

--- a/.metrics/oneclick_log.csv
+++ b/.metrics/oneclick_log.csv
@@ -1,0 +1,2 @@
+timestamp,pr_number,user,status
+


### PR DESCRIPTION
## Summary
- add an issue comment-driven workflow to run npm tests on `/dry-run` and auto-merge on `/apply`
- restrict `/apply` to writers, require green CI, and log merges to `.metrics/oneclick_log.csv`
- seed the merge log with a CSV header for operator visibility

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d998acf9f4832e85102100d327a14d