### PR TITLE
Update one-click workflow to log in markdown

### DIFF
--- a/.github/workflows/oneclick.yml
+++ b/.github/workflows/oneclick.yml
@@ -174,8 +174,8 @@ jobs:
 
             const timestamp = new Date().toISOString();
             const status = 'merged';
-            const logLine = `${timestamp},${pull_number},${commenter},${status}`;
-            const logPath = '.metrics/oneclick_log.csv';
+            const logLine = `| ${timestamp} | ${pull_number} | ${commenter} | ${status} |`;
+            const logPath = '.metrics/oneclick_log.md';
 
             let existingContent = '';
             let currentSha;
@@ -196,7 +196,7 @@ jobs:
               currentSha = contentData.sha;
             } catch (error) {
               if (error.status === 404) {
-                existingContent = 'timestamp,pr_number,user,status\n';
+                existingContent = '| timestamp | pr_number | user | status |\n| --- | --- | --- | --- |\n';
               } else {
                 throw error;
               }


### PR DESCRIPTION
## Summary
- update the /apply workflow logging to use `.metrics/oneclick_log.md`
- ensure missing logs are initialised with a markdown table header
- append new merge entries as markdown table rows to preserve formatting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9a332bbec832eb9a64d5f064a067b